### PR TITLE
[fix]移动消息监听的位置，便于后期对消息进行维护

### DIFF
--- a/src/main/java/moe/d2n/ink/mirai/event/EventServer.java
+++ b/src/main/java/moe/d2n/ink/mirai/event/EventServer.java
@@ -79,7 +79,7 @@ public class EventServer {
             if (latch.await(3, TimeUnit.MINUTES)) {
                 return result.get();
             } else {
-                InkEngine.Log().debug("获取用户下一条消息超时");
+                InkEngine.log().debug("获取用户下一条消息超时");
                 return null;
             }
         } catch (InterruptedException e) {

--- a/src/main/java/moe/d2n/ink/mirai/event/MessageEventListener.java
+++ b/src/main/java/moe/d2n/ink/mirai/event/MessageEventListener.java
@@ -1,8 +1,21 @@
 package moe.d2n.ink.mirai.event;
 
+import com.bladecoder.ink.runtime.Story;
+import moe.d2n.ink.core.ChoiceException;
+import moe.d2n.ink.mirai.InkEngine;
+import moe.d2n.ink.mirai.MiraiPluginConfig;
+import moe.d2n.ink.mirai.MiraiStoryContext;
+import net.mamoe.mirai.contact.NormalMember;
 import net.mamoe.mirai.event.EventHandler;
 import net.mamoe.mirai.event.SimpleListenerHost;
 import net.mamoe.mirai.event.events.GroupMessageEvent;
+import net.mamoe.mirai.message.data.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static moe.d2n.ink.mirai.utils.FileUtil.readStr;
+import static moe.d2n.ink.mirai.utils.InkUtil.checkSDKVersion;
 
 /**
  * 消息事件监听
@@ -12,13 +25,101 @@ import net.mamoe.mirai.event.events.GroupMessageEvent;
  */
 public class MessageEventListener extends SimpleListenerHost {
 
+    /**
+     * 缓存
+     */
+    public Story story;
+    /**
+     * 群上下文
+     */
+    public Map<Long, Map<Long, MiraiStoryContext>> groupStoryMap = new HashMap<>();
+    /**
+     * 插件本体
+     */
+    public InkEngine inkEngine = InkEngine.INSTANCE;
+    /**
+     * 配置
+     */
+    private MiraiPluginConfig config = InkEngine.INSTANCE.config;
+
 
     /**
      * 群消息入口
+     *
      * @param event 消息事件
      */
     @EventHandler
     public void messageEntry(GroupMessageEvent event) {
 
+        String msg = event.getMessage().contentToString();
+
+        /*
+        todo 这里应该做的事
+        1.匹配自定义指令
+        2.匹配呼出信息
+        后续操作通过 EventServer.nextUserMessageForGroup(x,x)持续监听
+         */
+
+        if (config.getDevMode() && msg.equals("/reload")) {
+            try {
+                story = new Story(readStr(
+                        inkEngine.getDataFolderPath().resolve("data").resolve(config.getMainFile()).toFile()
+                ));
+                checkSDKVersion(story);
+                groupStoryMap = new HashMap<>();
+                event.getGroup().sendMessage("重载成功");
+                return;
+            } catch (Exception ignored) {
+            }
+        }
+
+        boolean hasChoose = false;
+        int chooseNum = 0;
+
+        At at = null;
+        for (SingleMessage singleMessage : event.getMessage()) {
+            if (singleMessage instanceof At) {
+                at = (At) singleMessage;
+            } else if (singleMessage instanceof PlainText) {
+                var text = (PlainText) singleMessage;
+                try {
+                    chooseNum = Integer.parseInt(text.contentToString().trim());
+                    hasChoose = true;
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        NormalMember chooseTarget = null;
+        if (at != null) {
+            chooseTarget = event.getGroup().get(at.getTarget());
+            hasChoose = chooseTarget != null;
+        }
+
+        if (hasChoose && chooseTarget != null && chooseTarget.getId() == event.getSender().getId()) {
+            event.getGroup().sendMessage("你不能选择自己");
+            return;
+        }
+
+        if (!msg.startsWith(config.getCommand()) && !hasChoose) {
+            return;
+        }
+
+        var memberStory = inkEngine.getContext(event.getSender());
+
+        try {
+            if (memberStory.choose(chooseNum, chooseTarget)) {
+                var smsg = memberStory.getMessage();
+                var mb = new MessageChainBuilder();
+                mb.append(MessageSource.quote(event.getMessage()));
+                smsg.forEach(mb::append);
+                event.getGroup().sendMessage(mb.asMessageChain());
+            }
+        } catch (ChoiceException ex) {
+            event.getGroup().sendMessage(ex.getMessage());
+        }
+
     }
+
+
 }

--- a/src/main/java/moe/d2n/ink/mirai/utils/FileUtil.java
+++ b/src/main/java/moe/d2n/ink/mirai/utils/FileUtil.java
@@ -1,0 +1,35 @@
+package moe.d2n.ink.mirai.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * 文件工具
+ *
+ * @author Moyuyanli
+ * @date 2024/6/18 10:42
+ */
+public class FileUtil {
+
+    private FileUtil() {
+    }
+
+    /**
+     * 读取文件
+     *
+     * @param file 文件
+     * @return 文件内容
+     * @throws IOException io异常
+     */
+    public static String readStr(File file) throws IOException {
+        var result = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+        if (result.startsWith("\uFEFF")) {
+            result = result.substring(1);
+        }
+        return result;
+    }
+
+
+}

--- a/src/main/java/moe/d2n/ink/mirai/utils/InkUtil.java
+++ b/src/main/java/moe/d2n/ink/mirai/utils/InkUtil.java
@@ -1,0 +1,30 @@
+package moe.d2n.ink.mirai.utils;
+
+import com.bladecoder.ink.runtime.Story;
+import moe.d2n.ink.mirai.InkEngine;
+
+import static moe.d2n.ink.mirai.InkEngine.INK_SDK_VERSION;
+
+/**
+ * ink工具
+ *
+ * @author Moyuyanli
+ * @date 2024/6/18 10:44
+ */
+public class InkUtil {
+
+    private InkUtil() {
+    }
+
+
+    public static boolean checkSDKVersion(Story story) {
+        int version = (Integer) story.getVariablesState().get("SDK_VERSION");
+        boolean flag = version <= INK_SDK_VERSION;
+        if (flag) {
+            InkEngine.log().warning("当前插件版本过低，请更新至最新版本");
+            InkEngine.log().warning("当前插件支持的SDK版本： " + INK_SDK_VERSION + " ，故事SDK版本： " + version);
+        }
+        return flag;
+    }
+
+}


### PR DESCRIPTION
fix:移动消息监听位置
feat：添加文件工具
feat：添加ink工具
todo: 修改响应逻辑

只是把监听位置挪了，具体功能跟上下文有关，我没太理解，就没动。
